### PR TITLE
Fixes: [rel=noreferrer] is not added when element has no existing [rel]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "posthtml-external-link",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,19 +28,19 @@ export function posthtmlExternalLink(
           }
         }
 
-        if (node.attrs.rel) {
-          const rels = new Set(node.attrs.rel.split(/\s+/));
-          rels.add('noopener');
-          rels.add('nofollow');
-          rels.add('external');
-          if (config.noreferrer) {
-            rels.add('noreferrer');
-          }
+        // :: append rels to the element's [rel] value.
+        //    failsafes in case [rel] is not defined yet.
+        // const rels = new Set((node.attrs.rel || '').split(/\s+/));
+        const rels = node.attrs.rel
+          ? new Set(node.attrs.rel.split(/\s+/))
+          : new Set()
 
-          node.attrs.rel = Array.from(rels).join(' ');
-        } else {
-          node.attrs.rel = 'noopener nofollow external';
-        }
+        config.noreferrer && rels.add('noreferrer')
+        rels.add('noopener');
+        rels.add('nofollow');
+        rels.add('external');
+
+        node.attrs.rel = Array.from(rels).join(' ');
 
         node.attrs.target = '_blank';
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,6 @@ export function posthtmlExternalLink(
 
         // :: append rels to the element's [rel] value.
         //    failsafes in case [rel] is not defined yet.
-        // const rels = new Set((node.attrs.rel || '').split(/\s+/));
         const rels = node.attrs.rel
           ? new Set(node.attrs.rel.split(/\s+/))
           : new Set()

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,9 +32,10 @@ export function posthtmlExternalLink(
         //    failsafes in case [rel] is not defined yet.
         const rels = node.attrs.rel
           ? new Set(node.attrs.rel.split(/\s+/))
-          : new Set()
+          : new Set();
 
-        config.noreferrer && rels.add('noreferrer')
+        // config.noreferrer && rels.add('noreferrer');
+        if (config.noreferrer) rels.add('noreferrer');
         rels.add('noopener');
         rels.add('nofollow');
         rels.add('external');

--- a/test/test.ts
+++ b/test/test.ts
@@ -87,20 +87,20 @@ describe('posthtml-external-link', () => {
       const input = '<a href="https://example.com" rel="example">Example</a>';
       const { html: result } = await parser.process(input);
 
-      result.should.include(' rel="example noreferrer noopener nofollow external"')
-    })
+      result.should.include(' rel="example noreferrer noopener nofollow external"');
+    });
 
     it('adds noreferrer even to elements without an existing [rel]', async () => {
       const parser = posthtml([plugin({
         exclude: ['skk.moe'],
         noreferrer: true
-      })])
+      })]);
 
       const input = '<a href="https://example.com">Example</a>';
       const { html: result } = await parser.process(input);
 
-      result.should.include(' rel="noreferrer noopener nofollow external"')
-    })
+      result.should.include(' rel="noreferrer noopener nofollow external"');
+    });
 
     it('target attr', async () => {
       const { html: result } = await posthtml([plugin({ exclude: ['skk.moe'] })]).process('<a href="https://example.com/" target="_self">Example</a>');

--- a/test/test.ts
+++ b/test/test.ts
@@ -78,6 +78,30 @@ describe('posthtml-external-link', () => {
       result.should.include('" target="_blank"');
     });
 
+    it('adds noreferrer when config is set', async () => {
+      const parser = posthtml([plugin({
+        exclude: ['skk.moe'],
+        noreferrer: true
+      })]);
+
+      const input = '<a href="https://example.com" rel="example">Example</a>';
+      const { html: result } = await parser.process(input);
+
+      result.should.include(' rel="example noreferrer noopener nofollow external"')
+    })
+
+    it('adds noreferrer even to elements without an existing [rel]', async () => {
+      const parser = posthtml([plugin({
+        exclude: ['skk.moe'],
+        noreferrer: true
+      })])
+
+      const input = '<a href="https://example.com">Example</a>';
+      const { html: result } = await parser.process(input);
+
+      result.should.include(' rel="noreferrer noopener nofollow external"')
+    })
+
     it('target attr', async () => {
       const { html: result } = await posthtml([plugin({ exclude: ['skk.moe'] })]).process('<a href="https://example.com/" target="_self">Example</a>');
 


### PR DESCRIPTION
When an element has no pre-existing `[rel]` (e.g. `<a href="#">Example</a>`), the `config.noreferrer` value is not respected. Even when `config.noreferrer: true`, the output HTML still does **not** include `[rel=noreferrer]`.

This PR fixes that, so that `config.noreferrer` is respected regardless of what the pre-existing `[rel]` values are.